### PR TITLE
Make it possible to disable strict parsing in email module

### DIFF
--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -69,6 +69,19 @@ of the new API.
 
    If *strict* is true, use a strict parser which rejects malformed inputs.
 
+   The default setting for *strict* is set to ``True``, but you can override
+   it by setting the environment variable ``PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING``
+   to non-empty string.
+
+   Additionally, you can permanently set the default value for *strict* to
+   ``False`` by creating the configuration file ``/etc/python/email.cfg``
+   with the following content:
+
+   .. code-block:: ini
+
+      [email_addr_parsing]
+      PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING = true
+
    .. versionchanged:: 3.13
       Add *strict* optional parameter and reject malformed inputs by default.
 
@@ -96,6 +109,19 @@ of the new API.
    :meth:`Message.get_all <email.message.Message.get_all>`.
 
    If *strict* is true, use a strict parser which rejects malformed inputs.
+
+   The default setting for *strict* is set to ``True``, but you can override
+   it by setting the environment variable ``PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING``
+   to non-empty string.
+
+   Additionally, you can permanently set the default value for *strict* to
+   ``False`` by creating the configuration file ``/etc/python/email.cfg``
+   with the following content:
+
+   .. code-block:: ini
+
+      [email_addr_parsing]
+      PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING = true
 
    Here's a simple example that gets all the recipients of a message::
 

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -49,43 +49,44 @@ specialsre = re.compile(r'[][\\()<>@,:;".]')
 escapesre = re.compile(r'[\\"]')
 
 _EMAIL_CONFIG_FILE = "/etc/python/email.cfg"
+_cached_strict_addr_parsing = None
 
 
 def _use_strict_email_parsing():
+    """"Cache implementation for _cached_strict_addr_parsing"""
+    global _cached_strict_addr_parsing
+    if _cached_strict_addr_parsing is None:
+        _cached_strict_addr_parsing = _use_strict_email_parsing_impl()
+    return _cached_strict_addr_parsing
+
+
+def _use_strict_email_parsing_impl():
     """Returns True if strict email parsing is not disabled by
     config file or env variable.
     """
-    global _cached_strict_addr_parsing
+    disabled = bool(os.environ.get("PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING"))
+    if disabled:
+        return False
 
     try:
-        return _cached_strict_addr_parsing
-    except NameError:
-        disabled = bool(os.environ.get("PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING"))
-        if disabled:
-            _cached_strict_addr_parsing = False
-            return _cached_strict_addr_parsing
+        file = open(_EMAIL_CONFIG_FILE)
+    except FileNotFoundError:
+        pass
+    else:
+        with file:
+            import configparser
+            config = configparser.ConfigParser(
+                interpolation=None,
+                comment_prefixes=('#', ),
 
-        try:
-            file = open(_EMAIL_CONFIG_FILE)
-        except FileNotFoundError:
-            pass
-        else:
-            with file:
-                import configparser
-                config = configparser.ConfigParser(
-                    interpolation=None,
-                    comment_prefixes=('#', ),
+            )
+            config.read_file(file)
+            disabled = config.getboolean('email_addr_parsing', "PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING", fallback=None)
 
-                )
-                config.read_file(file)
-                disabled = config.getboolean('email_addr_parsing', "PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING", fallback=None)
+    if disabled:
+        return False
 
-        if disabled:
-            _cached_strict_addr_parsing = False
-            return _cached_strict_addr_parsing
-
-        _cached_strict_addr_parsing = True
-        return _cached_strict_addr_parsing
+    return True
 
 
 def _has_surrogates(s):

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -48,6 +48,45 @@ TICK = "'"
 specialsre = re.compile(r'[][\\()<>@,:;".]')
 escapesre = re.compile(r'[\\"]')
 
+_EMAIL_CONFIG_FILE = "/etc/python/email.cfg"
+
+
+def _use_strict_email_parsing():
+    """Returns True if strict email parsing is not disabled by
+    config file or env variable.
+    """
+    global _cached_strict_addr_parsing
+
+    try:
+        return _cached_strict_addr_parsing
+    except NameError:
+        disabled = bool(os.environ.get("PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING"))
+        if disabled:
+            _cached_strict_addr_parsing = False
+            return _cached_strict_addr_parsing
+
+        try:
+            file = open(_EMAIL_CONFIG_FILE)
+        except FileNotFoundError:
+            pass
+        else:
+            with file:
+                import configparser
+                config = configparser.ConfigParser(
+                    interpolation=None,
+                    comment_prefixes=('#', ),
+
+                )
+                config.read_file(file)
+                disabled = config.getboolean('email_addr_parsing', "PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING", fallback=None)
+
+        if disabled:
+            _cached_strict_addr_parsing = False
+            return _cached_strict_addr_parsing
+
+        _cached_strict_addr_parsing = True
+        return _cached_strict_addr_parsing
+
 
 def _has_surrogates(s):
     """Return True if s contains surrogate-escaped binary data."""
@@ -149,7 +188,7 @@ def _strip_quoted_realnames(addr):
 
 supports_strict_parsing = True
 
-def getaddresses(fieldvalues, *, strict=True):
+def getaddresses(fieldvalues, *, strict=None):
     """Return a list of (REALNAME, EMAIL) or ('','') for each fieldvalue.
 
     When parsing fails for a fieldvalue, a 2-tuple of ('', '') is returned in
@@ -157,6 +196,11 @@ def getaddresses(fieldvalues, *, strict=True):
 
     If strict is true, use a strict parser which rejects malformed inputs.
     """
+
+    # If default is used, it's True unless disabled
+    # by env variable or config file.
+    if strict == None:
+        strict = _use_strict_email_parsing()
 
     # If strict is true, if the resulting list of parsed addresses is greater
     # than the number of fieldvalues in the input list, a parsing error has
@@ -330,7 +374,7 @@ def parsedate_to_datetime(data):
             tzinfo=datetime.timezone(datetime.timedelta(seconds=tz)))
 
 
-def parseaddr(addr, *, strict=True):
+def parseaddr(addr, *, strict=None):
     """
     Parse addr into its constituent realname and email address parts.
 
@@ -339,6 +383,11 @@ def parseaddr(addr, *, strict=True):
 
     If strict is True, use a strict parser which rejects malformed inputs.
     """
+    # If default is used, it's True unless disabled
+    # by env variable or config file.
+    if strict == None:
+        strict = _use_strict_email_parsing()
+
     if not strict:
         addrs = _AddressList(addr).addresslist
         if not addrs:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -7,6 +7,9 @@ import time
 import base64
 import unittest
 import textwrap
+import contextlib
+import tempfile
+import os
 
 from io import StringIO, BytesIO
 from itertools import chain
@@ -41,7 +44,7 @@ from email import iterators
 from email import base64mime
 from email import quoprimime
 
-from test.support import unlink, start_threads
+from test.support import unlink, start_threads, EnvironmentVarGuard
 from test.test_email import openfile, TestEmailBase
 
 # These imports are documented to work, but we are testing them using a
@@ -3312,6 +3315,78 @@ Foo
 
         # Test email.utils.supports_strict_parsing attribute
         self.assertEqual(email.utils.supports_strict_parsing, True)
+
+    def test_parsing_errors_strict_disabled_via_env_var(self):
+        address = 'alice@example.org )Alice('
+        empty = ('', '')
+
+        # Delete cached default value to make the function
+        # reload the environment variable provided below.
+        try:
+            del utils._cached_strict_addr_parsing
+        except AttributeError:
+            pass
+
+        # Strict disabled via env variable, old behavior expected
+        with EnvironmentVarGuard() as environ:
+            environ["PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING"] = "1"
+
+            self.assertEqual(utils.getaddresses([address]),
+                             [('', 'alice@example.org'), ('', ''), ('', 'Alice')])
+            self.assertEqual(utils.parseaddr([address]), ('', address))
+
+        # Clear cache again
+        try:
+            del utils._cached_strict_addr_parsing
+        except AttributeError:
+            pass
+
+        # Default strict=True, empty result expected
+        self.assertEqual(utils.getaddresses([address]), [empty])
+        self.assertEqual(utils.parseaddr([address]), empty)
+
+    @contextlib.contextmanager
+    def _email_strict_parsing_conf(self):
+        """Context for the given email strict parsing configured in config file"""
+        old_filename = utils._EMAIL_CONFIG_FILE
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                filename = os.path.join(tmpdirname, 'conf.cfg')
+                with open(filename, 'w') as file:
+                    file.write('[email_addr_parsing]\n')
+                    file.write('PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING = true')
+                utils._EMAIL_CONFIG_FILE = filename
+                yield
+        finally:
+            utils._EMAIL_CONFIG_FILE = old_filename
+
+    def test_parsing_errors_strict_disabled_via_config_file(self):
+        address = 'alice@example.org )Alice('
+        empty = ('', '')
+
+        # Delete cached default value to make the function
+        # reload the config file provided below.
+        try:
+            del utils._cached_strict_addr_parsing
+        except AttributeError:
+            pass
+
+        # Strict disabled via config file, old results expected
+        with self._email_strict_parsing_conf():
+            self.assertEqual(utils.getaddresses([address]),
+                             [('', 'alice@example.org'), ('', ''), ('', 'Alice')])
+            self.assertEqual(utils.parseaddr([address]), ('', address))
+
+        # Clear cache again
+        try:
+            del utils._cached_strict_addr_parsing
+        except AttributeError:
+            pass
+
+        # Default strict=True, empty result expected
+        self.assertEqual(utils.getaddresses([address]), [empty])
+        self.assertEqual(utils.parseaddr([address]), empty)
 
     def test_getaddresses_nasty(self):
         for addresses, expected in (

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3320,12 +3320,9 @@ Foo
         address = 'alice@example.org )Alice('
         empty = ('', '')
 
-        # Delete cached default value to make the function
-        # reload the environment variable provided below.
-        try:
-            del utils._cached_strict_addr_parsing
-        except AttributeError:
-            pass
+        # Reset cached default value to make the function
+        # reload the config file provided below.
+        utils._cached_strict_addr_parsing = None
 
         # Strict disabled via env variable, old behavior expected
         with EnvironmentVarGuard() as environ:
@@ -3336,20 +3333,14 @@ Foo
             self.assertEqual(utils.parseaddr([address]), ('', address))
 
         # Clear cache again
-        try:
-            del utils._cached_strict_addr_parsing
-        except AttributeError:
-            pass
+        utils._cached_strict_addr_parsing = None
 
         # Default strict=True, empty result expected
         self.assertEqual(utils.getaddresses([address]), [empty])
         self.assertEqual(utils.parseaddr([address]), empty)
 
         # Clear cache again
-        try:
-            del utils._cached_strict_addr_parsing
-        except AttributeError:
-            pass
+        utils._cached_strict_addr_parsing = None
 
         # Empty string in env variable = strict parsing enabled (default)
         with EnvironmentVarGuard() as environ:
@@ -3375,12 +3366,9 @@ Foo
         address = 'alice@example.org )Alice('
         empty = ('', '')
 
-        # Delete cached default value to make the function
+        # Reset cached default value to make the function
         # reload the config file provided below.
-        try:
-            del utils._cached_strict_addr_parsing
-        except AttributeError:
-            pass
+        utils._cached_strict_addr_parsing = None
 
         # Strict disabled via config file, old results expected
         with self._email_strict_parsing_conf():
@@ -3389,10 +3377,7 @@ Foo
             self.assertEqual(utils.parseaddr([address]), ('', address))
 
         # Clear cache again
-        try:
-            del utils._cached_strict_addr_parsing
-        except AttributeError:
-            pass
+        utils._cached_strict_addr_parsing = None
 
         # Default strict=True, empty result expected
         self.assertEqual(utils.getaddresses([address]), [empty])

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -44,7 +44,7 @@ from email import iterators
 from email import base64mime
 from email import quoprimime
 
-from test.support import unlink, start_threads, EnvironmentVarGuard
+from test.support import unlink, start_threads, EnvironmentVarGuard, swap_attr
 from test.test_email import openfile, TestEmailBase
 
 # These imports are documented to work, but we are testing them using a
@@ -3362,18 +3362,14 @@ Foo
     @contextlib.contextmanager
     def _email_strict_parsing_conf(self):
         """Context for the given email strict parsing configured in config file"""
-        old_filename = utils._EMAIL_CONFIG_FILE
-
-        try:
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                filename = os.path.join(tmpdirname, 'conf.cfg')
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            filename = os.path.join(tmpdirname, 'conf.cfg')
+            with swap_attr(utils, "_EMAIL_CONFIG_FILE", filename):
                 with open(filename, 'w') as file:
                     file.write('[email_addr_parsing]\n')
                     file.write('PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING = true')
                 utils._EMAIL_CONFIG_FILE = filename
                 yield
-        finally:
-            utils._EMAIL_CONFIG_FILE = old_filename
 
     def test_parsing_errors_strict_disabled_via_config_file(self):
         address = 'alice@example.org )Alice('

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3316,7 +3316,7 @@ Foo
         # Test email.utils.supports_strict_parsing attribute
         self.assertEqual(email.utils.supports_strict_parsing, True)
 
-    def test_parsing_errors_strict_disabled_via_env_var(self):
+    def test_parsing_errors_strict_set_via_env_var(self):
         address = 'alice@example.org )Alice('
         empty = ('', '')
 
@@ -3344,6 +3344,20 @@ Foo
         # Default strict=True, empty result expected
         self.assertEqual(utils.getaddresses([address]), [empty])
         self.assertEqual(utils.parseaddr([address]), empty)
+
+        # Clear cache again
+        try:
+            del utils._cached_strict_addr_parsing
+        except AttributeError:
+            pass
+
+        # Empty string in env variable = strict parsing enabled (default)
+        with EnvironmentVarGuard() as environ:
+            environ["PYTHON_EMAIL_DISABLE_STRICT_ADDR_PARSING"] = ""
+
+            # Default strict=True, empty result expected
+            self.assertEqual(utils.getaddresses([address]), [empty])
+            self.assertEqual(utils.parseaddr([address]), empty)
 
     @contextlib.contextmanager
     def _email_strict_parsing_conf(self):


### PR DESCRIPTION
I am creating a PR for easier review. This single commit is meant to be applied in RHEL after the patch 415 with the actual fix from the upstream.

This is a solution we (with @encukou) came up with.

Documentation change TBD when the implementation is approved.